### PR TITLE
Made compatible with CoffeeScript 2.5.1

### DIFF
--- a/lib/jquery.js
+++ b/lib/jquery.js
@@ -1962,7 +1962,7 @@ function dataAttr( elem, key, data ) {
 function isEmptyDataObject( obj ) {
 	for ( var name in obj ) {
 
-		// if the public data object is empty, the private is still empty
+		// if the publicInterface data object is empty, the private is still empty
 		if ( name === "data" && jQuery.isEmptyObject( obj[name] ) ) {
 			continue;
 		}
@@ -2834,7 +2834,7 @@ var rformElems = /^(?:textarea|input|select)$/i,
 	};
 
 /*
- * Helper functions for managing events -- not part of the public interface.
+ * Helper functions for managing events -- not part of the publicInterface interface.
  * Props to Dean Edwards' addEvent library for many of the ideas.
  */
 jQuery.event = {
@@ -6018,7 +6018,7 @@ function cloneCopyEvent( src, dest ) {
 		}
 	}
 
-	// make the cloned public data object a copy from the original
+	// make the cloned publicInterface data object a copy from the original
 	if ( curData.data ) {
 		curData.data = jQuery.extend( {}, curData.data );
 	}

--- a/src/aabb.coffee
+++ b/src/aabb.coffee
@@ -7,5 +7,5 @@ class AABB
     vec3.subtract @vec2, @vec1, vec3.create()
 
 
-public = self.webglmc ?= {}
-public.AABB = AABB
+publicInterface = self.webglmc ?= {}
+publicInterface.AABB = AABB

--- a/src/atlas.coffee
+++ b/src/atlas.coffee
@@ -90,5 +90,5 @@ class AtlasBuilder
     new Atlas texture, slices
 
 
-public = self.webglmc ?= {}
-public.AtlasBuilder = AtlasBuilder
+publicInterface = self.webglmc ?= {}
+publicInterface.AtlasBuilder = AtlasBuilder

--- a/src/camera.coffee
+++ b/src/camera.coffee
@@ -68,5 +68,5 @@ class Camera
     engine.view.set mv
 
 
-public = self.webglmc ?= {}
-public.Camera = Camera
+publicInterface = self.webglmc ?= {}
+publicInterface.Camera = Camera

--- a/src/contextobj.coffee
+++ b/src/contextobj.coffee
@@ -47,6 +47,7 @@ class GLFlagContextObject extends ContextObject
   @withStack 'gl_flags'
 
   constructor: (funcs) ->
+    super()
     this.bind = funcs.bind
     this.unbind = funcs.unbind
 

--- a/src/contextobj.coffee
+++ b/src/contextobj.coffee
@@ -71,8 +71,8 @@ disabledDepthTest = new GLFlagContextObject
     gl.enable gl.DEPTH_TEST
 
 
-public = self.webglmc ?= {}
-public.ContextObject = ContextObject
-public.getContextObjectStacks = -> stacks
-public.withContext = withContext
-public.disabledDepthTest = disabledDepthTest
+publicInterface = self.webglmc ?= {}
+publicInterface.ContextObject = ContextObject
+publicInterface.getContextObjectStacks = -> stacks
+publicInterface.withContext = withContext
+publicInterface.disabledDepthTest = disabledDepthTest

--- a/src/debugpanel.coffee
+++ b/src/debugpanel.coffee
@@ -47,7 +47,7 @@ bench = (benchName, callback) ->
   display.setText "#{(Date.now() - now) / 1000}ms"
 
 
-public = self.webglmc ?= {}
-public.DebugPanel = DebugPanel
-public.getRuntimeParameter = getRuntimeParameter
-public.bench = bench
+publicInterface = self.webglmc ?= {}
+publicInterface.DebugPanel = DebugPanel
+publicInterface.getRuntimeParameter = getRuntimeParameter
+publicInterface.bench = bench

--- a/src/engine.coffee
+++ b/src/engine.coffee
@@ -173,6 +173,6 @@ class MatrixStack
     webglmc.engine.markMVPDirty()
 
 
-public = self.webglmc ?= {}
-public.Engine = Engine
-public.clear = clear
+publicInterface = self.webglmc ?= {}
+publicInterface.Engine = Engine
+publicInterface.clear = clear

--- a/src/fbo.coffee
+++ b/src/fbo.coffee
@@ -10,6 +10,7 @@ class RenderBufferObject extends webglmc.ContextObject
 
   constructor: (width, height, format) ->
     {gl} = webglmc.engine
+    super()
     @format = gl[format]
     @id = gl.createRenderbuffer()
     this.push()
@@ -33,6 +34,7 @@ class FrameBufferObject extends webglmc.ContextObject
 
   constructor: (width, height, options = {}) ->
     {gl} = webglmc.engine
+    super()
     @width = width ? webglmc.engine.width
     @height = height ? webglmc.engine.height
     @id = gl.createFramebuffer()

--- a/src/fbo.coffee
+++ b/src/fbo.coffee
@@ -67,6 +67,6 @@ class FrameBufferObject extends webglmc.ContextObject
     gl.bindFramebuffer gl.FRAMEBUFFER, null
 
 
-public = self.webglmc ?= {}
-public.RenderBufferObject = RenderBufferObject
-public.FrameBufferObject = FrameBufferObject
+publicInterface = self.webglmc ?= {}
+publicInterface.RenderBufferObject = RenderBufferObject
+publicInterface.FrameBufferObject = FrameBufferObject

--- a/src/frustum.coffee
+++ b/src/frustum.coffee
@@ -84,5 +84,5 @@ class Frustum
     if pointsVisible == 48 then 1 else 0
 
 
-public = self.webglmc ?= {}
-public.Frustum = Frustum
+publicInterface = self.webglmc ?= {}
+publicInterface.Frustum = Frustum

--- a/src/game.coffee
+++ b/src/game.coffee
@@ -115,8 +115,8 @@ $(document).ready ->
   initEngineAndGame '#viewport', debug
 
 
-public = self.webglmc ?= {}
-public.game = null
-public.debugPanel = null
-public.resmgr = null
-public.engine = null
+publicInterface = self.webglmc ?= {}
+publicInterface.game = null
+publicInterface.debugPanel = null
+publicInterface.resmgr = null
+publicInterface.engine = null

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -42,9 +42,9 @@ nextPowerOfTwo = (value) ->
   value + 1
 
 
-public = self.webglmc ?= {}
-public.dirname = dirname
-public.joinFilename = joinFilename
-public.autoShortenFilename = autoShortenFilename
-public.floatColorFromHex = floatColorFromHex
-public.nextPowerOfTwo = nextPowerOfTwo
+publicInterface = self.webglmc ?= {}
+publicInterface.dirname = dirname
+publicInterface.joinFilename = joinFilename
+publicInterface.autoShortenFilename = autoShortenFilename
+publicInterface.floatColorFromHex = floatColorFromHex
+publicInterface.nextPowerOfTwo = nextPowerOfTwo

--- a/src/perlin.coffee
+++ b/src/perlin.coffee
@@ -214,5 +214,5 @@ class PerlinGenerator
     total
 
 
-public = self.webglmc ?= {}
-public.PerlinGenerator = PerlinGenerator
+publicInterface = self.webglmc ?= {}
+publicInterface.PerlinGenerator = PerlinGenerator

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -151,5 +151,5 @@ class CubeMaker
     vbo
 
 
-public = self.webglmc ?= {}
-public.CubeMaker = CubeMaker
+publicInterface = self.webglmc ?= {}
+publicInterface.CubeMaker = CubeMaker

--- a/src/process.coffee
+++ b/src/process.coffee
@@ -106,10 +106,10 @@ class ProcessManager
     this.updateDisplay()
 
 
-public = self.webglmc ?= {}
-public.Process = Process
-public.ProcessManager = ProcessManager
-public.startProcess = startProcess
+publicInterface = self.webglmc ?= {}
+publicInterface.Process = Process
+publicInterface.ProcessManager = ProcessManager
+publicInterface.startProcess = startProcess
 
 
 if startWorkerSupport

--- a/src/processor.coffee
+++ b/src/processor.coffee
@@ -16,6 +16,7 @@ class Processor extends webglmc.ContextObject
   @withStack 'processor'
 
   constructor: (shader, fbo = null) ->
+    super()
     @shader = shader
     if fbo
       @fbo = fbo

--- a/src/processor.coffee
+++ b/src/processor.coffee
@@ -47,5 +47,5 @@ class Processor extends webglmc.ContextObject
     @shader.pop()
 
 
-public = self.webglmc ?= {}
-public.Processor = Processor
+publicInterface = self.webglmc ?= {}
+publicInterface.Processor = Processor

--- a/src/ray.coffee
+++ b/src/ray.coffee
@@ -71,6 +71,6 @@ class Ray
     if didHit then new RaycastHit(lowt, sideHit) else null
 
 
-public = self.webglmc ?= {}
-public.Ray = Ray
-public.RaycastHit = RaycastHit
+publicInterface = self.webglmc ?= {}
+publicInterface.Ray = Ray
+publicInterface.RaycastHit = RaycastHit

--- a/src/resmgr.coffee
+++ b/src/resmgr.coffee
@@ -97,5 +97,5 @@ class ResourceManager
         callback webglmc.Texture.fromImage(image, def)
 
 
-public = self.webglmc ?= {}
-public.ResourceManager = ResourceManager
+publicInterface = self.webglmc ?= {}
+publicInterface.ResourceManager = ResourceManager

--- a/src/resources.coffee
+++ b/src/resources.coffee
@@ -21,5 +21,5 @@ makeDefaultResourceManager = ->
   resmgr
 
 
-public = self.webglmc ?= {}
-public.makeDefaultResourceManager = makeDefaultResourceManager
+publicInterface = self.webglmc ?= {}
+publicInterface.makeDefaultResourceManager = makeDefaultResourceManager

--- a/src/shaders.coffee
+++ b/src/shaders.coffee
@@ -160,6 +160,6 @@ class Shader extends webglmc.ContextObject
     gl.destroyShader @fragmentShader
 
 
-public = self.webglmc ?= {}
-public.Shader = Shader
-public.loadShader = loadShader
+publicInterface = self.webglmc ?= {}
+publicInterface.Shader = Shader
+publicInterface.loadShader = loadShader

--- a/src/shaders.coffee
+++ b/src/shaders.coffee
@@ -88,6 +88,7 @@ class Shader extends webglmc.ContextObject
   constructor: (source, filename = null) ->
     {gl} = webglmc.engine
 
+    super()
     @prog = gl.createProgram()
     @vertexShader = shaderFromSource 'VERTEX_SHADER', source, filename
     @fragmentShader = shaderFromSource 'FRAGMENT_SHADER', source, filename

--- a/src/texture.coffee
+++ b/src/texture.coffee
@@ -112,5 +112,5 @@ class TextureSlice extends Texture
     @unit = texture.unit
 
 
-public = self.webglmc ?= {}
-public.Texture = Texture
+publicInterface = self.webglmc ?= {}
+publicInterface.Texture = Texture

--- a/src/texture.coffee
+++ b/src/texture.coffee
@@ -41,6 +41,7 @@ class Texture extends webglmc.ContextObject
   @withStack 'texture'
 
   constructor: (width, height, storedWidth, storedHeight, offsetX, offsetY) ->
+    super()
     @id = -1
     @unit = 0
     @width = width

--- a/src/vbo.coffee
+++ b/src/vbo.coffee
@@ -47,6 +47,7 @@ class VertexBufferObject extends webglmc.ContextObject
   @withStack 'vbo'
 
   constructor: (drawMode, count, options = {}) ->
+    super()
     @drawMode = webglmc.engine.gl[drawMode]
     @count = count
     @interleaved = options.interleaved ? true

--- a/src/vbo.coffee
+++ b/src/vbo.coffee
@@ -167,5 +167,5 @@ class VertexBufferObject extends webglmc.ContextObject
     this.pop()
 
 
-public = self.webglmc ?= {}
-public.VertexBufferObject = VertexBufferObject
+publicInterface = self.webglmc ?= {}
+publicInterface.VertexBufferObject = VertexBufferObject

--- a/src/world.coffee
+++ b/src/world.coffee
@@ -381,6 +381,6 @@ class World
         vbo.draw()
 
 
-public = self.webglmc ?= {}
-public.World = World
-public.BLOCK_TYPES = BLOCK_TYPES
+publicInterface = self.webglmc ?= {}
+publicInterface.World = World
+publicInterface.BLOCK_TYPES = BLOCK_TYPES

--- a/src/worldgen.coffee
+++ b/src/worldgen.coffee
@@ -32,6 +32,7 @@ class GeneratorState
 
 class WorldGeneratorProcess extends webglmc.Process
   constructor: (seed) ->
+    super()
     @perlin = new webglmc.PerlinGenerator seed
     @cachedState = null
     @cachedChunk = null

--- a/src/worldgen.coffee
+++ b/src/worldgen.coffee
@@ -185,6 +185,6 @@ class WorldGenerator
     @world.setRequestedChunk x, y, z, chunk
 
 
-public = self.webglmc ?= {}
-public.WorldGenerator = WorldGenerator
-public.WorldGeneratorProcess = WorldGeneratorProcess
+publicInterface = self.webglmc ?= {}
+publicInterface.WorldGenerator = WorldGenerator
+publicInterface.WorldGeneratorProcess = WorldGeneratorProcess


### PR DESCRIPTION
There are two breaking changes that seem to affect webgl-meincraft; the use of this in extended classes before calling super(), and the use of the now reserved keyword 'public'.